### PR TITLE
Add PostgreSQLDialect for EXCEPT instead of MINUS

### DIFF
--- a/core/src/main/scala/org/tresql/QueryBuilder.scala
+++ b/core/src/main/scala/org/tresql/QueryBuilder.scala
@@ -133,7 +133,7 @@ class QueryBuilder private (val env: Env, private val queryDepth: Int,
     override def exprType: Class[_] = if ("-" == op) operand.exprType else classOf[ConstExpr]
   }
 
-  class BinExpr(val op: String, val lop: Expr, val rop: Expr) extends BaseExpr {
+  case class BinExpr(val op: String, val lop: Expr, val rop: Expr) extends BaseExpr {
     override def apply() = {
       def selCols(ex: Expr): List[QueryBuilder#ColExpr] = {
         ex match {

--- a/core/src/main/scala/org/tresql/dialects/PostgreSQLDialect.scala
+++ b/core/src/main/scala/org/tresql/dialects/PostgreSQLDialect.scala
@@ -1,0 +1,13 @@
+package org.tresql.dialects
+
+import org.tresql.Expr
+
+object PostgreSQLDialect extends (Expr=>String) {
+
+  def apply(e: Expr) = e match {
+    case e.builder.BinExpr("-", lop, rop) =>
+      lop.sql + (if (e.exprType.getSimpleName == "SelectExpr") " except " else " - ") + rop.sql
+    case _ => e.defaultSQL
+  }
+
+}


### PR DESCRIPTION
PostgreSQL uses EXCEPT instead of MINUS.
Not sure about getSimpleName - please refactor to your taste.

``` sql
demo=> select 1 union select 2 except select 2 except select 2;
 ?column? 
----------
        1
(1 row)
```

MSSQL uses EXCEPT too, afaik.
